### PR TITLE
request: handle error replies correctly

### DIFF
--- a/request.go
+++ b/request.go
@@ -84,7 +84,10 @@ func (req *multiRequest) close() {
 }
 
 // handleReply is responsible for adding a result to the result set
-func (req *multiRequest) handleReply(_ error, addr net.IP, tRecv *time.Time) {
+func (req *multiRequest) handleReply(err error, addr net.IP, tRecv *time.Time) {
+	if err != nil {
+		return
+	}
 	// avoid blocking
 	go func() {
 		req.mtx.RLock()


### PR DESCRIPTION
Before this change, I encountered panics like this one:

```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6bf24f]

  goroutine 205 [running]:
  github.com/digineo/go-ping.(*multiRequest).handleReply.func1(0xc0003bfe00, 0x0, 0x0, 0x0, 0x0)
  	/home/michael/go/pkg/mod/github.com/digineo/go-ping@v1.0.0/request.go:96 +0x8f
  created by github.com/digineo/go-ping.(*multiRequest).handleReply
  	/home/michael/go/pkg/mod/github.com/digineo/go-ping@v1.0.0/request.go:89
	+0x67
```

With an example program like this one:

```go
  func repro() (string, error) {
	bind6 := "::"
	addr, err := net.ResolveIPAddr("ip", "ff02::2%enp3s0f1")
	if err != nil {
		return "", err
	}
	p, err := ping.New("", bind6)
	if err != nil {
		return "", err
	}
	defer p.Close()
	const timeout = 5 * time.Second
	ctx, canc := context.WithTimeout(context.Background(), timeout)
	defer canc()

	log.Printf("ff02:: code path")
	replies, err := p.PingMulticastContext(ctx, addr)
	if err != nil {
		return "", err
	}
	addrs, err := net.InterfaceAddrs()
	if err != nil {
		return "", err
	}
	localAddr := make(map[string]bool)
	for _, addr := range addrs {
		ipnet, ok := addr.(*net.IPNet)
		if !ok {
			continue
		}
		localAddr[ipnet.IP.String()] = true
	}
	for reply := range replies {
		if localAddr[reply.Address.String()] {
			continue
		}
		go func() {
			for range replies {
				// drain channel
			}
		}()
		return fmt.Sprint(reply.Duration) + " from " + reply.Address.String(), nil
	}
	return "", fmt.Errorf("no responses to %s within %v", addr, timeout)
  }
```