### PR TITLE
Add ability to change the ICMP ID and seq counter

### DIFF
--- a/receiving.go
+++ b/receiving.go
@@ -98,17 +98,14 @@ func (pinger *Pinger) process(body icmp.MessageBody, result error, addr net.IP, 
 		return
 	}
 
-	// check if we sent this
-	if uint16(echo.ID) != pinger.id {
-		return
-	}
+	idseq := (uint32(uint16(echo.ID)) << 16) | uint32(uint16(echo.Seq))
 
 	// search for existing running echo request
 	pinger.mtx.Lock()
-	req := pinger.requests[uint16(echo.Seq)]
+	req := pinger.requests[idseq]
 	if _, ok := req.(*simpleRequest); ok {
 		// a simpleRequest is finished on the first reply
-		delete(pinger.requests, uint16(echo.Seq))
+		delete(pinger.requests, idseq)
 	}
 	pinger.mtx.Unlock()
 


### PR DESCRIPTION
It is sometimes valuable to be able to change the ICMP echo `identifier` field (in particular, this is often used by NAT gateways to tie packets to a particular NAT session, and it may not be desirable for all pingers in the same program to be associated wth the same NAT session).

This change exposes the ID as a field in Pinger which can be overridden by the caller (defaults to PID as before).  It can actually even be changed while the pinger is running without issues.

Also, since one can now have different pingers with different identifiers, it might be desirable to have them use independent sequence values, so the ability to override the sequence counter used has also been added (since it was easy).

(This change is actually required for some improvements I am working on to the Prometheus ping_exporter..)