### PR TITLE
Allow set fwmark to icmp connection

### DIFF
--- a/cmd/pingnet/main.go
+++ b/cmd/pingnet/main.go
@@ -26,6 +26,7 @@ var (
 	size     = uint(56)
 	force    bool
 	verbose  bool
+	mark     uint
 	pinger   *ping.Pinger
 )
 
@@ -84,6 +85,7 @@ func main() {
 	flag.IntVar(&poolSize, "P", poolSize, "concurrency level")
 	flag.BoolVar(&force, "f", force, "sanity flag needed if you want to ping more than 4096 hosts (/20)")
 	flag.BoolVar(&verbose, "v", verbose, "also print out unreachable addresses")
+	flag.UintVar(&mark, "m", mark, "set socket mark (SO_MARK) to this value")
 	flag.Parse()
 
 	// simple error checking
@@ -125,6 +127,10 @@ func main() {
 		log.Fatal(err)
 	} else {
 		pinger = p
+	}
+
+	if mark > 0 {
+		pinger.SetMark(mark)
 	}
 
 	// prepare worker

--- a/pinger_linux.go
+++ b/pinger_linux.go
@@ -1,0 +1,66 @@
+package ping
+
+import (
+	"errors"
+	"os"
+	"reflect"
+	"syscall"
+
+	"golang.org/x/net/icmp"
+)
+
+// getFD gets the system file descriptor for an icmp.PacketConn
+func getFD(c *icmp.PacketConn) (uintptr, error) {
+	v := reflect.ValueOf(c).Elem().FieldByName("c").Elem()
+	if v.Elem().Kind() != reflect.Struct {
+		return 0, errors.New("invalid type")
+	}
+
+	fd := v.Elem().FieldByName("conn").FieldByName("fd")
+	if fd.Elem().Kind() != reflect.Struct {
+		return 0, errors.New("invalid type")
+	}
+
+	pfd := fd.Elem().FieldByName("pfd")
+	if pfd.Kind() != reflect.Struct {
+		return 0, errors.New("invalid type")
+	}
+
+	return uintptr(pfd.FieldByName("Sysfd").Int()), nil
+}
+
+func (pinger *Pinger) SetMark(mark uint) error {
+	conn4, ok := pinger.conn4.(*icmp.PacketConn)
+	if !ok {
+		return errors.New("invalid connection type")
+	}
+
+	fd, err := getFD(conn4)
+	if err != nil {
+		return err
+	}
+
+	err = os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, int(mark)),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	conn6, ok := pinger.conn6.(*icmp.PacketConn)
+	if !ok {
+		return errors.New("invalid connection type")
+	}
+
+	fd, err = getFD(conn6)
+	if err != nil {
+		return err
+	}
+
+	return os.NewSyscallError(
+		"setsockopt",
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, int(mark)),
+	)
+}

--- a/pinger_other.go
+++ b/pinger_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package ping
+
+import "errors"
+
+func (pinger *Pinger) SetMark(mark uint) error {
+	return errors.New("setting SO_MARK socket option is not supported on this platform")
+}


### PR DESCRIPTION
Tested on linux. Set fwmark allow user to use policy based routing select route for ICMP request

<img width="2016" height="368" alt="image" src="https://github.com/user-attachments/assets/2d51c1ca-5517-4004-8f25-2060109ff4f3" />
